### PR TITLE
Functional tests for Radar

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,19 @@
+require("xunit-file");
+
+module.exports = function (grunt) {
+  grunt.initConfig({
+    simplemocha: {
+      options: {
+        globals: ["should"],
+        timeout: 30000,
+        ignoreLeaks: false,
+        ui: "bdd",
+        reporter: "xunit-file"
+      },
+      all: { src: ["./test.js"] }
+    }
+  });
+  grunt.loadNpmTasks("grunt-express-server");
+  grunt.loadNpmTasks("grunt-simple-mocha");
+  grunt.registerTask("default", ["simplemocha:all"]);
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "radar-ft",
+  "version": "1.0.0",
+  "description": "Demo functional tests for the Shippable Radar app",
+  "scripts": {
+    "test": "grunt"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shippablesamples/radar-ft.git"
+  },
+  "author": "Shippable",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/shippablesamples/radar-ft/issues"
+  },
+  "homepage": "https://github.com/shippablesamples/radar-ft#readme",
+  "devDependencies": {
+    "chai": "^3.0.0",
+    "grunt": "^0.4.0",
+    "grunt-express-server": "^0.5.1",
+    "grunt-simple-mocha": "^0.4.0",
+    "istanbul": "^0.3.14",
+    "mocha": "^2.2.5",
+    "should": "^6.0.3",
+    "superagent": "^1.2.0",
+    "xunit-file": "0.0.6"
+  }
+}

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,28 @@
+# language setting
+language: node_js
+
+# version numbers, testing against one version of node
+node_js:
+    - 0.10.33
+
+env:
+    - XUNIT_FILE=./shippable/testresults/result.xml
+    - URL=http://104.236.198.94:17210 #url of the deployed formation
+    - secure: #encrypted variable TOKEN
+    # TOKEN is a GitHub token for the subscription triggering the build
+
+before_install:
+    - node --version
+    - npm install -g grunt-cli
+    - mkdir -p ./shippable/testresults
+    - mkdir -p ./shippable/codecoverage
+
+install:
+    - npm install
+
+script:
+    - grunt
+
+after_script:
+    - ./node_modules/.bin/istanbul cover grunt -- -u tdd
+    - ./node_modules/.bin/istanbul report cobertura --dir  ./shippable/codecoverage/

--- a/test.js
+++ b/test.js
@@ -1,0 +1,72 @@
+var superagent = require("superagent");
+var chai = require("chai");
+var expect = chai.expect;
+var should = require("should");
+
+var URL = process.env.URL;
+var token = process.env.TOKEN;
+
+// don't run the rest of the tests until we get a response
+describe("Index", function () {
+  this.timeout(255000);
+
+  it("renders something", retryFunction.bind(null, 10, 500));
+
+  function retryFunction(maxTries, interval, done) {
+    superagent.get(URL)
+    .end(function (err, res) {
+      if (res) {
+        (err === null).should.equal(true);
+        res.statusCode.should.equal(200);
+        done();
+      } else if (maxTries > 0) {
+        setTimeout(function() {
+          retryFunction(maxTries - 1, Math.min(254000, interval * 2), done);
+        }, interval);
+      } else {
+        // no response
+        expect(URL, URL + ' is unavailable').to.equal(true);
+      }
+    });
+  }
+});
+
+describe("Open issues", function () {
+  it("renders open issues info", function (done) {
+    superagent.get(URL + "/issues?repo=shippable/support&token=" + token +
+      "&days=2&daysEnd=5&state=Open")
+    .end(function (err, res) {
+      (err === null).should.equal(true);
+      res.should.be.json;
+      res.text.should.containEql("open");
+      res.statusCode.should.equal(200);
+      done();
+    });
+  });
+});
+
+describe("Closed issues", function () {
+  it("renders closed issues info", function (done) {
+    superagent.get(URL + "/issues?repo=shippable/support&token=" + token +
+      "&days=2&daysEnd=5&state=Close")
+    .end(function (err, res) {
+      (err === null).should.equal(true);
+      res.should.be.json;
+      res.text.should.containEql("close");
+      res.statusCode.should.equal(200);
+      done();
+    });
+  });
+});
+
+describe("Failed auth", function () {
+  it("Should not render issues page, instead main page", function (done) {
+    superagent.get(URL + "/issues?repo=shippable/support&token=" +
+      "no&days=2&daysEnd=5&state=Open")
+    .end(function (err, res) {
+      res.text.should.not.containEql("open");
+      res.text.should.not.containEql("close");
+      done();
+    });
+  });
+});

--- a/xunit.xml
+++ b/xunit.xml
@@ -1,0 +1,6 @@
+<testsuite name="Mocha Tests" tests="4" failures="0" errors="0" skipped="0" timestamp="Thu, 13 Aug 2015 23:32:26 GMT" time="15.805">
+<testcase classname="Index" name="renders something" time="0.161"/>
+<testcase classname="Open issues" name="renders open issues info" time="1.995"/>
+<testcase classname="Closed issues" name="renders closed issues info" time="13.172"/>
+<testcase classname="Failed auth" name="Should not render issues page, instead main page" time="0.469"/>
+</testsuite>


### PR DESCRIPTION
Create a functional test repo for Radar.

To use:
- Set the URL env var in shippable.yml to the url of the deployed formation
- Encrypt a GitHub token for the subscription that will be triggering the build; put this secure environment var in the yml
- Trigger a build

Tested by running tests locally, against Radar running on localhost and on a deployed formation
